### PR TITLE
Add image generation env vars

### DIFF
--- a/.env
+++ b/.env
@@ -3,4 +3,6 @@ BOT_TOKEN=8385149393:AAGWQImLD1vC7YyHp5tcwqUtgmT0KznuVWc
 CHANNEL_ID=@testovidhe
 GEMINI_API_KEY=AIzaSyAJU3R3aIaLTdlJmP7KPXMR_5Mp4u3QEcE
 GEMINI_MODEL=gemini-2.5-flash
+ENABLE_IMAGE_GEN=true
+GEMINI_IMAGE_MODEL=gemini-2.0-flash-preview-image-generation
 # INITIAL_STORY_IDEA=Твой стартовый текст истории (одной строкой или с экранированными переводами строк)

--- a/render.yaml
+++ b/render.yaml
@@ -15,3 +15,7 @@ services:
         sync: false
       - key: GEMINI_MODEL
         value: gemini-2.5-flash
+      - key: ENABLE_IMAGE_GEN
+        value: true
+      - key: GEMINI_IMAGE_MODEL
+        value: gemini-2.0-flash-preview-image-generation


### PR DESCRIPTION
## Summary
- add ENABLE_IMAGE_GEN and GEMINI_IMAGE_MODEL to local .env
- expose image generation vars in render.yaml configuration

## Testing
- `python -m py_compile story_bot_gemini.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5b4240c5483338fbce02ca13bd81a